### PR TITLE
Preserve session counter for 10 minutes in case of game crash

### DIFF
--- a/AppLogic/StatsTracker.cs
+++ b/AppLogic/StatsTracker.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace SquatToBegin.AppLogic {
@@ -16,8 +13,8 @@ namespace SquatToBegin.AppLogic {
 			if(File.Exists(statsFilePath)) {
 				var content = File.ReadAllText(statsFilePath);
 				var lines = content.Split('\n');
-				if(int.TryParse(lines[0], out int alltime)) alltimeCounter = alltime;
-				if(Config.Instance.wtf && int.TryParse(lines[1], out var session) && DateTime.TryParse(lines[3], out var lastWrite)) {
+				if(int.TryParse(lines[0], out var alltime)) alltimeCounter = alltime;
+				if(Config.Instance.TryPreserveSession && int.TryParse(lines[1], out var session) && DateTime.TryParse(lines[2], out var lastWrite)) {
 					var now = DateTime.Now;
 					if(now - lastWrite < TimeSpan.FromMinutes(10)) {
 						Plugin.Log.Info("Restoring last session counter");

--- a/AppLogic/StatsTracker.cs
+++ b/AppLogic/StatsTracker.cs
@@ -14,10 +14,14 @@ namespace SquatToBegin.AppLogic {
 
 		public StatsTracker() {
 			if(File.Exists(statsFilePath)) {
-				using(var f = File.OpenRead(statsFilePath)) {
-					using(var r = new StreamReader(f)) {
-						if(!r.EndOfStream && int.TryParse(r.ReadLine(), out var alltimeCounter))
-							this.alltimeCounter = alltimeCounter;
+				var content = File.ReadAllText(statsFilePath);
+				var lines = content.Split('\n');
+				if(int.TryParse(lines[0], out int alltime)) alltimeCounter = alltime;
+				if(Config.Instance.wtf && int.TryParse(lines[1], out var session) && DateTime.TryParse(lines[3], out var lastWrite)) {
+					var now = DateTime.Now;
+					if(now - lastWrite < TimeSpan.FromMinutes(10)) {
+						Plugin.Log.Info("Restoring last session counter");
+						sessionCounter = session;
 					}
 				}
 
@@ -35,7 +39,8 @@ namespace SquatToBegin.AppLogic {
 		void WriteSquats() {
 			Task.Run(() => {
 				try {
-					File.WriteAllText(statsFilePath, $"{alltimeCounter}\n{sessionCounter}");
+					var lastWrite = DateTime.Now;
+					File.WriteAllText(statsFilePath, $"{alltimeCounter}\n{sessionCounter}\n{lastWrite}");
 				} catch { }
 			});
 		}

--- a/Config.cs
+++ b/Config.cs
@@ -14,6 +14,7 @@ namespace SquatToBegin {
 		public virtual bool Ding { get; set; } = true;
 		public virtual bool AppendBuiltinSounds { get; set; } = true;
 		public virtual bool CountSquatsDoneMidLevel { get; set; } = false;
+		public virtual bool wtf { get; set; } = true;
 
 		/*/// <summary>
 		/// This is called whenever BSIPA reads the config from disk (including when file changes are detected).

--- a/Config.cs
+++ b/Config.cs
@@ -14,7 +14,7 @@ namespace SquatToBegin {
 		public virtual bool Ding { get; set; } = true;
 		public virtual bool AppendBuiltinSounds { get; set; } = true;
 		public virtual bool CountSquatsDoneMidLevel { get; set; } = false;
-		public virtual bool wtf { get; set; } = true;
+		public virtual bool TryPreserveSession { get; set; } = true;
 
 		/*/// <summary>
 		/// This is called whenever BSIPA reads the config from disk (including when file changes are detected).

--- a/UI/settings.bsml
+++ b/UI/settings.bsml
@@ -10,6 +10,8 @@
 					min="0.2" max="1" increment="0.1"/>
 	<checkbox-setting apply-on-change="true" bind-value="true" value="CountSquatsDoneMidLevel" text="Count Squats done mid-level"
 					hover-hint="When enabled, squats that you do mid-level will also be counted :D"/>
+	<checkbox-setting apply-on-change="true" bind-value="true" value="wtf" text="Try preserve session counter"
+					hover-hint="Try to preserve the session counter in case of crashes or game restarts. Timeout is 10 minutes"/>
 	<checkbox-setting apply-on-change="true" bind-value="true" value="EnableAfterPause" text="Enable after Pause"/>
 	<checkbox-setting apply-on-change="true" bind-value="true" value="EnableInPractice" text="Enable in Practice"/>
 	<checkbox-setting apply-on-change="true" bind-value="true" value="Ding" text="Play a sound whenever a squat is counted"/>

--- a/UI/settings.bsml
+++ b/UI/settings.bsml
@@ -10,7 +10,7 @@
 					min="0.2" max="1" increment="0.1"/>
 	<checkbox-setting apply-on-change="true" bind-value="true" value="CountSquatsDoneMidLevel" text="Count Squats done mid-level"
 					hover-hint="When enabled, squats that you do mid-level will also be counted :D"/>
-	<checkbox-setting apply-on-change="true" bind-value="true" value="wtf" text="Try preserve session counter"
+	<checkbox-setting apply-on-change="true" bind-value="true" value="TryPreserveSession" text="Try preserve session counter"
 					hover-hint="Try to preserve the session counter in case of crashes or game restarts. Timeout is 10 minutes"/>
 	<checkbox-setting apply-on-change="true" bind-value="true" value="EnableAfterPause" text="Enable after Pause"/>
 	<checkbox-setting apply-on-change="true" bind-value="true" value="EnableInPractice" text="Enable in Practice"/>


### PR DESCRIPTION
Somebody complained in a twitch chat about restarting / crashing resetting their session stats, so went and did this